### PR TITLE
feat: create categories migration, seed and get-categories endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Migrations are saved in the /src/migrations folder
 - Create a migration and model with `$ sequelize model:generate --name Test2 --attributes firstName:string,lastName:string,email:string`
 - Run all migrations with `$ sequelize db:migrate --env development`
 - Rollback all migrations with `$ sequelize db:migrate:undo:all --env development`
+- Run database seed with `$ sequelize-cli db:seed:all`
 Always specify the environments
 
 #### Hints

--- a/__tests__/create-products.test.js
+++ b/__tests__/create-products.test.js
@@ -151,6 +151,8 @@ describe('User Registration Test', () => {
     done();
   });
 
+  // you can always comment out this test to prevent uploading image on every test
+
   test('it should create the product with an image and return the product_id', async (done) => {
     const userDetails = {
       firstName: chance.first(),

--- a/__tests__/get-categories.test.js
+++ b/__tests__/get-categories.test.js
@@ -1,0 +1,36 @@
+import supertest from 'supertest';
+import http from 'http';
+import app from '../src/app';
+
+process.env.NODE_ENV = 'test';
+
+describe('get categories test', () => {
+  let server;
+  let request;
+
+  beforeAll((done) => {
+    server = http.createServer(app);
+    server.listen(done);
+    request = supertest(server);
+    jest.setTimeout(10 * 1000);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  test('it should return status of 200', async (done) => {
+    const res = await request.get('/api/v1/categories');
+
+    expect(res.status).toBe(200);
+    done();
+  });
+
+  test('it returns the categories', async (done) => {
+    const res = await request.get('/api/v1/categories');
+
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.categories).not.toBeNull();
+    done();
+  });
+});

--- a/app.properties
+++ b/app.properties
@@ -2,25 +2,25 @@
 # ================= 
 
 # name of the product 
-name:
+name: Silos
 
 # what SDG goal(s) does 
 # the product solve. this
 # should be the SDG goal number
-sdgs:
+sdgs: 2
 
 # name (not link) of repo
-repos:
+repos: Silos
 
 # URL(s) to the deplyed
 # app for the solution
 # e.g frontend UI app pr backend API
-app.urls:
+app.urls: https://silos-staging.herokuapp.com/api/v1  (staging)
 
 # URL(s) to the Codacy 
 # dashbaord for this repo
 # e.g https://app.codacy.com/gh/BuildForSDG/farmify-frontend/dashboard
-codacy.urls:
+codacy.urls: https://app.codacy.com/gh/BuildForSDG/silos/dashboard
 
 # YES if the solution
 # is solving for COVID-19
@@ -32,7 +32,7 @@ app.forCOVID19: NO
 # or its problem statement fall
 # under, e.g Agriculture
 # pick from this list : https://www.opensecrets.org/industries/alphalist.php
-app.industries:
+app.industries: Agriculture
 
 # about the codebase
 # ================== 
@@ -40,17 +40,17 @@ app.industries:
 # what are the major 
 # coding languages used
 # to create the solution
-code.languages:
+code.languages: JavaScript
 
 # what are the major 
 # frameworks and libraries
 # used to create the solution
-code.frameworks:
+code.frameworks: Node.js and React.js
 
 # what Facebook open source framework
 # library, tool, or platform API
 # is the codebase using
-code.opensource.facebook:
+code.opensource.facebook: React
 
 # If the team created something
 # as a by-product of building the 
@@ -62,11 +62,11 @@ code.opensource.contributions:
 # ==============
 
 # name of the team
-team.name:
+team.name: Team-020
 
 # github username
 # of the team's TTL(s)
-team.ttls:
+team.ttls: wincodes
 
 # github username
 # of the team's mentor(s)
@@ -76,7 +76,7 @@ team.mentors:
 # Slack channel in the
 # BuildforSDG Slack
 # workspace
-team.slackchannel:
+team.slackchannel: wincodes
 
 # == DO NOT EDIT ==
 # about the program

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "__tests__"
   },
   "scripts": {
-    "test": "sequelize db:migrate --env test && jest --detectOpenHandles && sequelize db:migrate:undo:all --env test",
+    "test": "sequelize db:migrate --env test && sequelize db:seed:all --env test && jest --detectOpenHandles && sequelize db:seed:undo --env test && sequelize db:migrate:undo:all --env test",
     "test:watch": "jest --watch",
     "test:cover": "jest --coverage",
     "lint": "eslint \"src/**/*.js\" .",
@@ -22,7 +22,8 @@
     "start": "apidoc -i src/ -o docs/ && babel-node --presets es2015 ./src/index.js",
     "docs": "apidoc -i src/ -o docs/",
     "test-migrate": "sequelize db:migrate --env test",
-    "test-migrate-rollback": "sequelize db:migrate:undo:all --env test"
+    "test-migrate-rollback": "sequelize db:migrate:undo:all --env test",
+    "test-run-seed": "sequelize db:seed:all --env test"
   },
   "husky": {
     "hooks": {

--- a/src/controller/utilityController.js
+++ b/src/controller/utilityController.js
@@ -1,0 +1,81 @@
+import sequelize from '../config/sequelize';
+
+const Category = sequelize.import('../models/category');
+
+/**
+ *
+ * @api {get} /api/v1/catgories Get all categories
+ * @apiName get Categories
+ * @apiGroup Categories
+ *
+ * @apiSuccessExample Success Response
+ * HTTP/1.1 200 OK
+ * {
+ *   "status": "success",
+ *  "data": {
+ *     "message": "Categories Fetched Succcessfully",
+ *     "categories":  [
+ *           {
+ *               "id": 1,
+ *               "name": "food",
+ *               "description": null
+ *           },
+ *           {
+ *               "id": 2,
+ *               "name": "live stock",
+ *               "description": null
+ *           },
+ *           {
+ *               "id": 3,
+ *               "name": "poultry",
+ *              "description": null
+ *           },
+ *       ]
+ *   }
+ * }
+ *
+ * @apiError Server Error
+ *
+ * @apiErrorExample Error Response:
+ * HTTP/1.1 500 Unauthorized
+ * {
+ *    "status": "error",
+ *    "data": {
+ *      "message":"Server Error",
+ *      "error": "Error information"
+ *    }
+ * }
+ */
+/* eslint-disable import/prefer-default-export */
+export const getCategories = async (req, res) => {
+  try {
+    // Find the user by primary key.
+    const categories = await Category.findAll({
+      attributes: { exclude: ['createdAt', 'updatedAt'] }
+    });
+
+    if (categories) {
+      return res.status(200).json({
+        status: 'success',
+        data: {
+          message: 'categories fetched successfully',
+          categories
+        }
+      });
+    }
+    return res.status(404).json({
+      status: 'error',
+      error: {
+        message: 'Categories not found.'
+      }
+    });
+  } catch (error) {
+    return res.status(500).json({
+      status: 'error',
+      error: {
+        message: 'Internal Server error',
+        error
+      }
+    });
+  }
+};

--- a/src/migrations/20200601155909-create-category.js
+++ b/src/migrations/20200601155909-create-category.js
@@ -1,0 +1,28 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('categories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    description: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('categories') // eslint-disable-line no-unused-vars
+};

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -1,0 +1,11 @@
+
+module.exports = (sequelize, DataTypes) => {
+  const Category = sequelize.define('category', {
+    name: DataTypes.STRING,
+    description: DataTypes.STRING
+  }, {});
+  // Category.associate = function(models) {
+  //   // associations can be defined here
+  // };
+  return Category;
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ import {
   getLandingPage, registerNewUser, userSignin, getUserProfile
 } from '../controller/userController';
 import auth from '../middleware/auth';
+import { getCategories } from '../controller/utilityController';
 
 const router = express.Router();
 
@@ -18,5 +19,6 @@ router.post('/auth/register', userValidationRules(), validate, registerNewUser);
 router.post('/auth/signin', loginValidationRules(), validate, userSignin);
 router.post('/products/create', auth, createProductValidationRules(), validate, createProduct);
 router.get('/users/:userId', auth, getUserProfile);
+router.get('/categories', getCategories);
 
 export default router;

--- a/src/seeders/20200601160911-categories.js
+++ b/src/seeders/20200601160911-categories.js
@@ -1,0 +1,56 @@
+
+/* eslint-disable implicit-arrow-linebreak */
+module.exports = {
+  up: (queryInterface, Sequelize) => // eslint-disable-line no-unused-vars
+    queryInterface.bulkInsert('categories', [{
+      name: 'food',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'live stock',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'poultry',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'fish and seafood',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'vegetables',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'fruits',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'grains',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      name: 'milk',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+    ], {}),
+
+  down: (queryInterface, Sequelize) => queryInterface.bulkDelete('categories', null, {}) // eslint-disable-line no-unused-vars
+};


### PR DESCRIPTION
## Description
Create categories migration, seed and get categories. 

https://github.com/BuildForSDG/silos/issues/15

## How Has This Been Tested?
This has been tested by running the dev server and going to the endpoint `/api/v1/categories`
also running the tests.


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
